### PR TITLE
github.com/pkg/errorsを試すコードを追加

### DIFF
--- a/pkg_errors/cmd/output/main.go
+++ b/pkg_errors/cmd/output/main.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"errors"
+
+	"fmt"
+	"io"
+
+	"github.com/akm/golang-sandbox/pkg_errors"
+)
+
+type CustomError struct {
+	Msg string
+}
+
+func NewCustomError(s string) *CustomError {
+	return &CustomError{s}
+}
+
+func (err *CustomError) Error() string {
+	return err.Msg
+}
+
+func main() {
+	errorSlice := []error{
+		pkgerrors.Foo(func() error {
+			return pkgerrors.StdNewError("stdErr1")
+		}),
+		pkgerrors.Foo(func() error {
+			return pkgerrors.StdWrapError(io.EOF, "stdErr2")
+		}),
+		pkgerrors.Foo(func() error {
+			return pkgerrors.StdWrapError(NewCustomError("CustomError1"), "stdErr3")
+		}),
+
+		pkgerrors.Foo(func() error {
+			return pkgerrors.PkgNewError("pkgErr1")
+		}),
+		pkgerrors.Foo(func() error {
+			return pkgerrors.PkgWrapError(io.EOF, "pkgErr2")
+		}),
+		pkgerrors.Foo(func() error {
+			return pkgerrors.PkgWrapError(NewCustomError("CustomError2"), "pkgErr3")
+		}),
+		pkgerrors.Foo(func() error {
+			return pkgerrors.PkgWrapError(
+				pkgerrors.Foo(func() error {
+					return io.EOF
+				}), "pkgErr3")
+		}),
+		pkgerrors.Foo(func() error {
+			return pkgerrors.PkgWrapError(
+				pkgerrors.Foo(func() error {
+					return pkgerrors.PkgNewError("pkgErr4")
+				}), "PkgErr4 MEMO")
+		}),
+	}
+
+	for idx, err := range errorSlice {
+		fmt.Printf("%d: v: %v\n", idx, err)
+
+		if errors.Is(err, io.EOF) {
+			fmt.Printf("%d: is EOF\n", idx)
+		} else {
+			fmt.Printf("%d: is NOT EOF\n", idx)
+		}
+
+		var cerr *CustomError
+		if errors.As(err, &cerr) {
+			fmt.Printf("%d: is CustomError: %v\n", idx, cerr)
+		} else {
+			fmt.Printf("%d: is NOT CustomError\n", idx)
+		}
+
+		{
+			cause := errors.Unwrap(err)
+			fmt.Printf("%d: errors.Unwrap: %T %v\n", idx, cause, cause)
+		}
+
+		fmt.Printf("%d: +v: %+v\n", idx, err)
+	}
+}

--- a/pkg_errors/go.mod
+++ b/pkg_errors/go.mod
@@ -1,0 +1,3 @@
+module github.com/akm/golang-sandbox/pkg_errors
+
+go 1.13

--- a/pkg_errors/go.mod
+++ b/pkg_errors/go.mod
@@ -1,3 +1,5 @@
 module github.com/akm/golang-sandbox/pkg_errors
 
 go 1.13
+
+require github.com/pkg/errors v0.9.1

--- a/pkg_errors/go.sum
+++ b/pkg_errors/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg_errors/main.go
+++ b/pkg_errors/main.go
@@ -1,0 +1,37 @@
+package pkgerrors
+
+import (
+	"fmt"
+
+	stderrors "errors"                // https://golang.org/pkg/errors/#pkg-index
+	pkgerrors "github.com/pkg/errors" // https://pkg.go.dev/github.com/pkg/errors
+	// "golang.org/x/xerrors" // https://pkg.go.dev/golang.org/x/xerrors
+)
+
+func Foo(f func() error) error {
+	return Bar(f)
+}
+
+func Bar(f func() error) error {
+	return Baz(f)
+}
+
+func Baz(f func() error) error {
+	return f()
+}
+
+func StdNewError(s string) error {
+	return stderrors.New(fmt.Sprintf("%s with stderrors.New", s))
+}
+
+func StdWrapError(err error, s string) error {
+	return fmt.Errorf("%s with std errors because of %w", s, err)
+}
+
+func PkgNewError(s string) error {
+	return pkgerrors.New(fmt.Sprintf("%s with pkgerrors.New", s))
+}
+
+func PkgWrapError(err error, s string) error {
+	return pkgerrors.Wrapf(err, "%s with pkgerrors.Wrapf", s)
+}


### PR DESCRIPTION
実行結果。納得できる結果が得られた

```
$ go run ./cmd/output
0: v: stdErr1 with stderrors.New
0: is NOT EOF
0: is NOT CustomError
0: errors.Unwrap: <nil> <nil>
0: +v: stdErr1 with stderrors.New
1: v: stdErr2 with std errors because of EOF
1: is EOF
1: is NOT CustomError
1: errors.Unwrap: *errors.errorString EOF
1: +v: stdErr2 with std errors because of EOF
2: v: stdErr3 with std errors because of CustomError1
2: is NOT EOF
2: is CustomError: CustomError1
2: errors.Unwrap: *main.CustomError CustomError1
2: +v: stdErr3 with std errors because of CustomError1
3: v: pkgErr1 with pkgerrors.New
3: is NOT EOF
3: is NOT CustomError
3: errors.Unwrap: <nil> <nil>
3: +v: pkgErr1 with pkgerrors.New
github.com/akm/golang-sandbox/pkg_errors.PkgNewError
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:32
main.main.func4
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/cmd/output/main.go:37
github.com/akm/golang-sandbox/pkg_errors.Baz
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:20
github.com/akm/golang-sandbox/pkg_errors.Bar
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:16
github.com/akm/golang-sandbox/pkg_errors.Foo
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:12
main.main
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/cmd/output/main.go:36
runtime.main
	/Users/takeshi/.anyenv/envs/goenv/versions/1.13.10/src/runtime/proc.go:203
runtime.goexit
	/Users/takeshi/.anyenv/envs/goenv/versions/1.13.10/src/runtime/asm_amd64.s:1357
4: v: pkgErr2 with pkgerrors.Wrapf: EOF
4: is EOF
4: is NOT CustomError
4: errors.Unwrap: *errors.withMessage pkgErr2 with pkgerrors.Wrapf: EOF
4: +v: EOF
pkgErr2 with pkgerrors.Wrapf
github.com/akm/golang-sandbox/pkg_errors.PkgWrapError
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:36
main.main.func5
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/cmd/output/main.go:40
github.com/akm/golang-sandbox/pkg_errors.Baz
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:20
github.com/akm/golang-sandbox/pkg_errors.Bar
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:16
github.com/akm/golang-sandbox/pkg_errors.Foo
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:12
main.main
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/cmd/output/main.go:39
runtime.main
	/Users/takeshi/.anyenv/envs/goenv/versions/1.13.10/src/runtime/proc.go:203
runtime.goexit
	/Users/takeshi/.anyenv/envs/goenv/versions/1.13.10/src/runtime/asm_amd64.s:1357
5: v: pkgErr3 with pkgerrors.Wrapf: CustomError2
5: is NOT EOF
5: is CustomError: CustomError2
5: errors.Unwrap: *errors.withMessage pkgErr3 with pkgerrors.Wrapf: CustomError2
5: +v: CustomError2
pkgErr3 with pkgerrors.Wrapf
github.com/akm/golang-sandbox/pkg_errors.PkgWrapError
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:36
main.main.func6
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/cmd/output/main.go:43
github.com/akm/golang-sandbox/pkg_errors.Baz
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:20
github.com/akm/golang-sandbox/pkg_errors.Bar
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:16
github.com/akm/golang-sandbox/pkg_errors.Foo
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:12
main.main
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/cmd/output/main.go:42
runtime.main
	/Users/takeshi/.anyenv/envs/goenv/versions/1.13.10/src/runtime/proc.go:203
runtime.goexit
	/Users/takeshi/.anyenv/envs/goenv/versions/1.13.10/src/runtime/asm_amd64.s:1357
6: v: pkgErr3 with pkgerrors.Wrapf: EOF
6: is EOF
6: is NOT CustomError
6: errors.Unwrap: *errors.withMessage pkgErr3 with pkgerrors.Wrapf: EOF
6: +v: EOF
pkgErr3 with pkgerrors.Wrapf
github.com/akm/golang-sandbox/pkg_errors.PkgWrapError
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:36
main.main.func7
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/cmd/output/main.go:46
github.com/akm/golang-sandbox/pkg_errors.Baz
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:20
github.com/akm/golang-sandbox/pkg_errors.Bar
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:16
github.com/akm/golang-sandbox/pkg_errors.Foo
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:12
main.main
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/cmd/output/main.go:45
runtime.main
	/Users/takeshi/.anyenv/envs/goenv/versions/1.13.10/src/runtime/proc.go:203
runtime.goexit
	/Users/takeshi/.anyenv/envs/goenv/versions/1.13.10/src/runtime/asm_amd64.s:1357
7: v: PkgErr4 MEMO with pkgerrors.Wrapf: pkgErr4 with pkgerrors.New
7: is NOT EOF
7: is NOT CustomError
7: errors.Unwrap: *errors.withMessage PkgErr4 MEMO with pkgerrors.Wrapf: pkgErr4 with pkgerrors.New
7: +v: pkgErr4 with pkgerrors.New
github.com/akm/golang-sandbox/pkg_errors.PkgNewError
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:32
main.main.func8.1
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/cmd/output/main.go:54
github.com/akm/golang-sandbox/pkg_errors.Baz
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:20
github.com/akm/golang-sandbox/pkg_errors.Bar
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:16
github.com/akm/golang-sandbox/pkg_errors.Foo
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:12
main.main.func8
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/cmd/output/main.go:53
github.com/akm/golang-sandbox/pkg_errors.Baz
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:20
github.com/akm/golang-sandbox/pkg_errors.Bar
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:16
github.com/akm/golang-sandbox/pkg_errors.Foo
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:12
main.main
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/cmd/output/main.go:51
runtime.main
	/Users/takeshi/.anyenv/envs/goenv/versions/1.13.10/src/runtime/proc.go:203
runtime.goexit
	/Users/takeshi/.anyenv/envs/goenv/versions/1.13.10/src/runtime/asm_amd64.s:1357
PkgErr4 MEMO with pkgerrors.Wrapf
github.com/akm/golang-sandbox/pkg_errors.PkgWrapError
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:36
main.main.func8
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/cmd/output/main.go:52
github.com/akm/golang-sandbox/pkg_errors.Baz
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:20
github.com/akm/golang-sandbox/pkg_errors.Bar
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:16
github.com/akm/golang-sandbox/pkg_errors.Foo
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/main.go:12
main.main
	/Users/takeshi/sandbox/golang-sandbox/pkg_errors/cmd/output/main.go:51
runtime.main
	/Users/takeshi/.anyenv/envs/goenv/versions/1.13.10/src/runtime/proc.go:203
runtime.goexit
	/Users/takeshi/.anyenv/envs/goenv/versions/1.13.10/src/runtime/asm_amd64.s:1357

```
